### PR TITLE
graphql subscription for real-time messages

### DIFF
--- a/src/schema/message.js
+++ b/src/schema/message.js
@@ -13,6 +13,14 @@ export default gql`
     updateMessage(id: ID!, text: String!): Boolean!
   }
 
+  extend type Subscription {
+    messageCreated: MessageCreated!
+  }
+
+  type MessageCreated {
+    message: Message!
+  }
+
   type MessageConnection {
     edges: [Message!]!
     pageInfo: PageInfo!

--- a/src/subscription/index.js
+++ b/src/subscription/index.js
@@ -1,0 +1,8 @@
+import { PubSub } from "apollo-server";
+import * as MESSAGE_EVENTS from "./message";
+
+export const EVENTS = {
+  MESSAGE: MESSAGE_EVENTS
+};
+
+export default new PubSub();

--- a/src/subscription/message.js
+++ b/src/subscription/message.js
@@ -1,0 +1,1 @@
+export const CREATED = "CREATED";


### PR DESCRIPTION
- Apollo subscript setup: http requests come with a req and res, however the subscription comes with a connection object
- PubSub for subscribing and publishing: implementing subscribing (the receiver) in subscription resolver and implementing publishing (the sender) in createMessage resolver. 
- Test the result at localhost:8000/graphql